### PR TITLE
Avoid exceptions disposing the dependency scope.

### DIFF
--- a/content/DependencyResolution/StructureMapDependencyScope.cs.pp
+++ b/content/DependencyResolution/StructureMapDependencyScope.cs.pp
@@ -64,11 +64,13 @@ namespace $rootnamespace$.DependencyResolution {
         #region Properties
 
         private HttpContextBase HttpContext {
-            get {
-                var ctx = Container.TryGetInstance<HttpContextBase>();
-                return ctx ?? new HttpContextWrapper(System.Web.HttpContext.Current);
-            }
-        }
+    	    get {
+                return (System.Web.HttpContext.Current == null
+        	    ? null
+        	    : (Container.TryGetInstance<HttpContextBase>() ??
+	                new HttpContextWrapper(System.Web.HttpContext.Current)));
+    	    }
+	}
 
         #endregion
 


### PR DESCRIPTION
When the Dispose method of the StructureMapDependencyScope is called, an exception is thrown trying to access to System.Web.HttpContext.Current. Checking the value before using it will avoid this exception.
